### PR TITLE
fix(int/express): remove content encoding if result is compressed

### DIFF
--- a/packages/api-construct/src/integrations/express/api-gateway-interop.ts
+++ b/packages/api-construct/src/integrations/express/api-gateway-interop.ts
@@ -87,10 +87,14 @@ export function wrapExpressHandler(handler: APIGatewayProxyHandler, hooks?: Serv
       return
     }
 
+    const body = result.isBase64Encoded ? decode(result.body) : result.body
+
+    if (result.isBase64Encoded) {
+      delete result.headers?.['content-encoding']
+    }
+
     res.status(result.statusCode)
     res.set(result.headers)
-
-    const body = result.isBase64Encoded ? decode(result.body) : result.body
 
     try {
       res.send(JSON.parse(body))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,42 +105,6 @@ importers:
         specifier: ^3.12.7
         version: 3.12.7
 
-  examples/basic/cdk.out/asset.1185430998627fe0eeebd2e379e7030bde3b88544d901511b7bfa9c5aead1ad0:
-    devDependencies:
-      '@types/aws-lambda':
-        specifier: ^8.10.119
-        version: 8.10.119
-
-  examples/basic/cdk.out/asset.5a10319f89b1d57432fbb815dbe3db2d92a1cc98c8266a7f713ecf942ed71375:
-    devDependencies:
-      '@types/aws-lambda':
-        specifier: ^8.10.119
-        version: 8.10.119
-
-  examples/basic/cdk.out/asset.5a10319f89b1d57432fbb815dbe3db2d92a1cc98c8266a7f713ecf942ed71375/d:
-    devDependencies:
-      '@types/aws-lambda':
-        specifier: ^8.10.119
-        version: 8.10.119
-
-  examples/basic/cdk.out/asset.6608c813d455b646ca5955cd7c25b6bda68b541c58bee2cb8029c25dc1750cdf:
-    devDependencies:
-      '@types/aws-lambda':
-        specifier: ^8.10.119
-        version: 8.10.119
-
-  examples/basic/cdk.out/asset.c24de59c359de37a560bb8db7f5d1d46c06308d2c78dc1b9bac3dedd425abab1:
-    devDependencies:
-      '@types/aws-lambda':
-        specifier: ^8.10.119
-        version: 8.10.119
-
-  examples/basic/cdk.out/asset.e6bdfd0fa059584253bb7e1196ae82287f0608ac7908b5190b12ff7edf576999:
-    devDependencies:
-      '@types/aws-lambda':
-        specifier: ^8.10.119
-        version: 8.10.119
-
   examples/basic/src/api/a:
     devDependencies:
       '@types/aws-lambda':
@@ -255,7 +219,7 @@ importers:
         version: 0.19.2
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0
+        version: 7.2.0(ts-node@10.9.1)(typescript@5.1.6)
       tsx:
         specifier: ^3.12.7
         version: 3.12.7
@@ -7310,25 +7274,6 @@ packages:
       pathe: 1.1.1
     dev: true
 
-  /postcss-load-config@4.0.1:
-    resolution:
-      {
-        integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==,
-      }
-    engines: { node: '>= 14' }
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      lilconfig: 2.1.0
-      yaml: 2.3.1
-    dev: true
-
   /postcss-load-config@4.0.1(ts-node@10.9.1):
     resolution:
       {
@@ -8618,44 +8563,6 @@ packages:
       {
         integrity: sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==,
       }
-    dev: true
-
-  /tsup@7.2.0:
-    resolution:
-      {
-        integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==,
-      }
-    engines: { node: '>=16.14' }
-    hasBin: true
-    peerDependencies:
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.1.0'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      bundle-require: 4.0.1(esbuild@0.18.17)
-      cac: 6.7.14
-      chokidar: 3.5.3
-      debug: 4.3.4
-      esbuild: 0.18.17
-      execa: 5.1.1
-      globby: 11.1.0
-      joycon: 3.1.1
-      postcss-load-config: 4.0.1
-      resolve-from: 5.0.0
-      rollup: 3.27.2
-      source-map: 0.8.0-beta.0
-      sucrase: 3.34.0
-      tree-kill: 1.2.2
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
     dev: true
 
   /tsup@7.2.0(ts-node@10.9.1)(typescript@5.1.6):


### PR DESCRIPTION
## Summary

The Express dev server incorrectly preserves the Content-Encoding header, even though it always returns a decompressed payload. This fix removes the offending header if the result was base64 encoded.